### PR TITLE
Timestamp: Batch Calls Using MediaWiki API

### DIFF
--- a/WebData.h
+++ b/WebData.h
@@ -22,7 +22,7 @@
 @property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;
 @property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 @property UILabel *feedbackLabel;
-
+@property NSDateFormatter *dateFormatter;
 
 /*
  //pjc
@@ -91,11 +91,11 @@
 
 - (void) storeBugImageWeb:(NSString *) bugName;
 
-- (void) storeImagesFromURLs:(NSDictionary *) bugsAndURLs;
+//- (void) storeImagesFromURLs:(NSDictionary *) bugsAndURLs;
 
 - (UIImage *) getImageWeb:(NSString *) file;
 
-- (NSDictionary*) getBugImageURLsWeb:(NSSet<NSString *> *) bugNames;
+//- (NSDictionary*) getBugImageURLsWeb:(NSSet<NSString *> *) bugNames;
 
 - (void) saveImage:(UIImage *)image withFileName:(NSString *)imageName ofType:(NSString *)extension;
 
@@ -115,6 +115,8 @@
 
 - (NSDate *) getLastSyncDate;
 
-- (NSDate *) getImageLastUpdateDate:(NSDateFormatter *) dateFormatter :(NSString *) imageUrl;
+- (NSMutableArray<NSDictionary*> *) getBugImageURLs:(NSSet<NSString *> *) bugNames;
+
+- (void) saveBugImages:(NSMutableArray<NSDictionary*> *) bugImages;
 
 @end

--- a/searchbar/SyncV3tvc.m
+++ b/searchbar/SyncV3tvc.m
@@ -227,12 +227,13 @@
         NSArray<Invertebrate *> *allBugs = [delegate.webData getBugsWeb:[allbugNames allObjects]];
         //[SVProgressHUD showProgress:.66 status:@"Linking Bugs to Streams ..."];
         success = [delegate.webData linkBugsToStreams:allBugs :streamsAndPopulations];
-        NSDictionary *allBugsWithImageURLs = [delegate.webData getBugImageURLsWeb:allbugNames];
+//        NSDictionary *allBugsWithImageURLs = [delegate.webData getBugImageURLsWeb:allbugNames];
+        NSMutableArray<NSDictionary *> *bugImages = [delegate.webData getBugImageURLs:allbugNames];
         NSLog(@"Done syncing... getting pictures");
         //[delegate.webData storeImagesFromURLs:allBugsWithImageURLs];
         NSThread* imageDLThread = [[NSThread alloc] initWithTarget:delegate.webData
-                                                     selector:@selector(storeImagesFromURLs:)
-                                                       object:allBugsWithImageURLs];
+                                                     selector:@selector(saveBugImages:)
+                                                       object:bugImages];
         double thisPriority = [[NSThread currentThread] threadPriority];
         [imageDLThread setThreadPriority:(thisPriority*.5)];
         [imageDLThread start];  // Actually start the thread


### PR DESCRIPTION
Thanks Pat and Steve. This is a better way to do it.

- Moved date formatter into WebData as a class member
- Get image timestamp via the API in bulk instead of via individual HEAD requests
- Deprecated some other functions